### PR TITLE
update and editorialise list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,52 @@
 ![Check Markdown links](https://github.com/shankari/covid-19-tracing-projects/workflows/Check%20Markdown%20links/badge.svg)
 
-- This site is a crowdsourced list of projects related to COVID-19 contact tracing using smartphones.
-- The goal of contact tracing is to identify the contacts of people who have tested positive for COVID-19 and to advise them to self-quarantine.
-- Large scale, highly accurate contact tracing could control the spread of epidemics and reduce the need for societal lockdowns.
-- There is another larger list in a [google doc](https://docs.google.com/document/d/16Kh4_Q_tmyRh0-v452wiul9oQAiTRj8AdZ5vcOJum9Y/edit?ts=5e801c37#).
-  Formed by the merging of Stop Covid Now's list, Corona Watch's and Mitra's. Please add projects there as well.
+This site is a crowdsourced list of projects related to **COVID-19 contact tracing using smartphones**.
+The goal of contact tracing is to identify the contacts of people who have tested positive for COVID-19 and to advise them to self-quarantine.
+Large scale, highly accurate contact tracing could control the spread of epidemics and reduce the need for societal lockdowns.
+
+Other list projects:
+- A larger list and some additional background can be found in this [google doc](https://docs.google.com/document/d/16Kh4_Q_tmyRh0-v452wiul9oQAiTRj8AdZ5vcOJum9Y/edit?ts=5e801c37#).
+  Formed by the merging of Stop Covid Now's list, Corona Watch's and Mitra's. 
+  Please add projects there as well.
 
 
 ## Tracking apps
 
+"Big projects" (loosely defined by GitHub stars, recent activity, endorsements or backers) are highlighted in **bold**.
+
 | Name and website link | github            | sensors used      | volunteer signup       | Notes |
 |-----------------------|-------------------|-------------------|------------------------|-------|
-| [COVID-APP](http://www.covid-app.de/) | ???? |       | http://www.covid-app.de/ | Privacy-preserving AI, Apheris AI collaborates w/ OpenMined |
-| [Infection Chain ](???) | ???? | QR code at shops and workplaces      | https://devpost.com/software/infection-chain | |
-| [Pandoa](https://pandoa.org/) | ???? | GPS      | https://devpost.com/software/08_pandoa-corona-virus-tracker | data on phone |
-| [BanDemic](http://bandemic.app/) | ???? | BLE      | https://bandemic.app/kontakt/ | Privacy aware, randomized keys, data on phone, protocol for integration into other apps |
-| [SafePaths](http://safepaths.mit.edu/) | ???? | location      | http://forms.gle/3fzhfJkq8kbF7uf89 | |
-| [CovidWatch](https://www.covid-watch.org/) | https://github.com/covid19risk | BLE         | Scroll to the end of https://www.covid-watch.org/ | Direct link to collaborate page doesn't work because of missing key. Google analytics?  |
-| [WHO App](https://spectrum.ieee.org/the-human-os/biomedical/devices/who-official-coronavirus-app-waze-covid19) | https://github.com/WorldHealthOrganization/ | None so far | https://github.com/WorldHealthOrganization/app/blob/master/docs/ONBOARDING.md | | 
-| [Hamagen, Israel MOH](https://medium.com/proferosec-osm/hamagen-application-fighiting-the-corona-virus-4ecf55eb4f7c) | https://github.com/MohGovIL/hamagen-react-native/ | location | https://github.com/MohGovIL/hamagen-react-native/blob/master/CONTRIBUTING.md | |
-| [DEGRAT](https://github.com/degregat/ppdt) | https://github.com/degregat/ppdt | BLE | ??? | | 
-| [Covid-FLutter](https://classworkdecjan.blogspot.com/2020/03/covid-project.html) | https://github.com/TheSciFiMed/Covid-FLutter | location      | http://bit.ly/Covid-Slack | |
-| [BlueTrace](https://bluetrace.io/) | code release pending | BLE | ??? | press release only, no code yet |
-| STRICT | https://github.com/ito-org/STRICT | BLE | | |
-| [Sygic](https://www.sygic.com/press/code-vs-corona-volunteers-and-developers-from-slovakia-are-offering-everyone-covid-19-app-for-free-as-open-source-software#) | | BLE | | |
+| [One Tracking Framework](https://github.com/OneTrackingFramework) | https://github.com/OneTrackingFramework | | | |
+| [Pandoa](https://pandoa.org/) | https://github.com/wirewirewirewire/pandoa | GPS  | https://devpost.com/software/08_pandoa-corona-virus-tracker | data on phone |
+| [**ito**](https://www.ito-app.org) | https://github.com/ito-org | BLE | https://start.ito-app.org | [formerly](https://twitter.com/BandemicApp/status/1247065639094816769) known as bluto, bandemic; privacy aware, randomized keys, data on phone, protocol for integration into other apps |
+| [**SafePaths**](http://safepaths.mit.edu/) | https://github.com/tripleblindmarket/covid-safe-paths | GPS | http://forms.gle/3fzhfJkq8kbF7uf89 | based on [PrivateKit](http://privatekit.mit.edu) |
+| [**CovidWatch**](https://www.covid-watch.org/) | https://github.com/covid19risk | BLE | https://www.covid-watch.org/collaborate | Uses [CEN Protocol](https://github.com/Co-Epi/CEN) |
+| [**CoEpi**](https://www.coepi.org) | https://github.com/Co-Epi | BLE | https://www.coepi.org/collaborations/ | Uses [CEN Protocol](https://github.com/Co-Epi/CEN) |
+| [Hamagen, Israel MOH](https://medium.com/proferosec-osm/hamagen-application-fighiting-the-corona-virus-4ecf55eb4f7c) | https://github.com/MohGovIL/hamagen-react-native/ | GPS | https://github.com/MohGovIL/hamagen-react-native/blob/master/CONTRIBUTING.md | |
+| [**BlueTrace**](https://bluetrace.io/) | [code release announced](https://www.cnbc.com/2020/03/25/coronavirus-singapore-to-make-contact-tracing-tech-open-source.html) | BLE | | aka. [**TraceTogether**](https://www.tracetogether.gov.sg), official aplication of Singapore's Ministry of Health |
+| [Covid World](https://www.sygic.com/press/code-vs-corona-volunteers-and-developers-from-slovakia-are-offering-everyone-covid-19-app-for-free-as-open-source-software) | https://github.com/CovidWorld | BLE | | |
 | [CoronaTrace](https://www.coronatrace.org/) | https://github.com/Corona-Trace | GPS | https://corona-trace.github.io/ |
-| [NextTrace](https://nexttrace.org/) | | GPS, BLE | https://nexttrace.org/contact | [Launch Tweetstorm](https://twitter.com/trvrb/status/1245240645003833345) |
-| [Pan-European Privacy-Preserving Proximity Tracing](https://www.pepp-pt.org/) | | BLE | info@pepp-pt.org | |
+| [NextTrace](https://nexttrace.org/) | | GPS, BLE | https://nexttrace.org/contact |  |
+| [**Pan-European Privacy-Preserving Proximity Tracing**](https://www.pepp-pt.org/) | [scheduled for 2020-04-07](https://www.golem.de/news/pepp-pt-neuer-standard-fuer-infektionswarnungen-vorgestellt-2004-147645.html) | BLE | info@pepp-pt.org | |
+| [Contact Tracing App](https://contacttracing.app/) | https://github.com/ContactTracing-app | none | | Contacts are manually entered (?) |
+| [contact-tracer](https://github.com/ehidra/contact-tracer) | https://github.com/ehidra/contact-tracer | BLE |  | Multiple clients |
+| [PrivateTracer](https://gitlab.com/PrivateTracer) | https://gitlab.com/PrivateTracer | BLE | https://gitlab.com/PrivateTracer/coordination | (Official?) dutch project |
+| [Covi-id](https://coviid.me) | | | | Landing page only? | 
+| [contact_tracing_covid19](https://github.com/vsnmtej/contact_tracing_covid19) | https://github.com/vsnmtej/contact_tracing_covid19 | BLE | | abandoned? |
+| [KeepDistance](https://github.com/manuelschlegel/code-vs-covid-19) | https://github.com/manuelschlegel/code-vs-covid-19 | BLE | | |
+| [hansel](https://gethansel.org) | https://github.com/gethansel/hansel | GPS | https://github.com/gethansel/hansel#getting-started | |
+| [covid19-contact-tracing](https://github.com/mbroecheler/covid19-contact-tracing) | https://github.com/mbroecheler/covid19-contact-tracing | agnostic | | Graph database backend |
+| [**Enigma SafeTrace**](https://blog.enigma.co/safetrace-privacy-preserving-contact-tracing-for-covid-19-c5ae8e1afa93) | https://github.com/enigmampc/SafeTrace | agnostic | https://github.com/enigmampc/SafeTrace/blob/master/CONTRIBUTE.md | Privacy perserving matching |
+| [**OpenMined**](http://openmined.org) | https://github.com/OpenMined | agnostic |  | Privacy perserving matching; efforts split across several projects |
+
+
+## Specs, Calls and Whitepapers
+
+| Name | Notes |
+|------|-------|
+| [COVID-APP](http://www.covid-app.de/) |  Privacy-preserving AI, Apheris AI collaborates w/ OpenMined |
+| [Privacy Preserving Disease Tracking](https://github.com/degregat/ppdt) |  | 
+| [10 requirements for the evaluation of 'Contact Tracing' apps](https://www.ccc.de/en/updates/2020/contact-tracing-requirements) | |
 
 
 ## Self-reported public database creation
@@ -50,15 +70,8 @@
 |-----------------------|-------|
 | [Covapp](https://covapp.charite.de/) | Questionnaire in EN /DE, can be combined with app/database for self-reporting |
 | [Apple COVID-19 Watch](https://www.apple.com/newsroom/2020/03/apple-releases-new-covid-19-app-and-website-based-on-CDC-guidance/) | |
+| [WHO App](https://github.com/WorldHealthOrganization/) | Unreleased |
 
-
-## Privacy-preserving matching
-
-| Name and website link | github | technique used | volunteer signup | Notes |
-|-----------------------|--------|----------------|------------------|-------|
-| [BanDemic](http://bandemic.app/) | ???? | BLE      | https://bandemic.app/kontakt/ | Privacy aware, randomized keys, data on phone, protocol for integration into other apps |
-| [Enigma SafeTrace](https://blog.enigma.co/safetrace-privacy-preserving-contact-tracing-for-covid-19-c5ae8e1afa93) | https://github.com/enigmampc/SafeTrace | secure enclaves | https://github.com/enigmampc/SafeTrace/blob/master/CONTRIBUTE.md | |
-| [OpenMined](http://openmined.org) | ??? | secure MPC | ??? | |
 
 
 ## Analysis on existing big data sources
@@ -84,7 +97,8 @@
 | 20 Mar | [Contact Tracing Mobile Apps for COVID-19: Privacy Considerations and Related Trade-offs](https://arxiv.org/abs/2003.11511) |
 | 19 Mar | [Apps Gone Rogue: Maintaining Personal Privacy in an Epidemic](https://arxiv.org/abs/2003.08567) |
 | 10 Feb | [Beyond R0: the important of contact tracing when predicting epidemics](https://arxiv.org/abs/2002.04004) |
-| 30 Mar | [Comparison of 4 mature German BLE-based tracking projects (in German)](https://linus-neumann.de/2020/03/corona-apps-sinn-und-unsinn-von-tracking/)
+| 30 Mar | [Comparison of 4 mature German BLE-based tracking projects (in German)](https://linus-neumann.de/2020/03/corona-apps-sinn-und-unsinn-von-tracking/) |
+| 31 Mar | [Quantifying SARS-CoV-2 transmission suggests epidemic control with digital contact tracing](https://science.sciencemag.org/content/early/2020/03/30/science.abb6936)|
 
 
 #### How can this site help?


### PR DESCRIPTION
Sorry about the monolithic PR; this includes a bunch of changes:

1. Mere specs and whitepapers have been relegated to their own category.
2. I deleted some dead projects (as per the maintainers)
3. Projects, which as per their own description, do not have contact tracing in scope have been removed
4. "big" projects are now in bold, just to make it a bit easier for people to navigate between the some--person-with-6-commits-projects and the huge projects. 
  Controversial, but I think necessary to keep this meaningful.
5. Updated/removed projects where they had merged.

More details/justification in github comments below.